### PR TITLE
Make python use virtual env

### DIFF
--- a/lua/hexdigest/plugins/nvim-lint.lua
+++ b/lua/hexdigest/plugins/nvim-lint.lua
@@ -14,5 +14,9 @@ return {
         require("lint").try_lint()
       end,
     })
+
+    -- Set pylint to work in virtualenv
+    require("lint").linters.pylint.cmd = "python"
+    require("lint").linters.pylint.args = { "-m", "pylint", "-f", "json" }
   end,
 }


### PR DESCRIPTION
Sometimes the linter doesn't see, to recognize the venv, even when sourcing it, before entering nvim
This config should fix this problem.

Config by [Norbiox](https://gist.github.com/Norbiox/652befc91ca0f90014aec34eccee27b2)