### PR TITLE
Stopping lsps from attaching twice

### DIFF
--- a/lua/hexdigest/plugins/lsp/mason.lua
+++ b/lua/hexdigest/plugins/lsp/mason.lua
@@ -1,49 +1,50 @@
 return {
-	"williamboman/mason.nvim",
-	dependencies = {
-		"williamboman/mason-lspconfig.nvim",
-		"WhoIsSethDaniel/mason-tool-installer.nvim",
-	},
-	config = function()
-		require("mason").setup()
+  "williamboman/mason.nvim",
+  dependencies = {
+    "williamboman/mason-lspconfig.nvim",
+    "WhoIsSethDaniel/mason-tool-installer.nvim",
+  },
+  config = function()
+    require("mason").setup()
 
-		require("mason-lspconfig").setup({
-			automatic_installation = true,
-			ensure_installed = {},
-		})
+    require("mason-lspconfig").setup({
+      automatic_installation = true,
+      ensure_installed = {},
+      automatic_enable = false,
+    })
 
-		require("mason-tool-installer").setup({
-			ensure_installed = {
-				"typescript-language-server",
-				"gopls",
-				"dockerls",
-				"svelte-language-server",
-				"tailwindcss-language-server",
-				"jdtls",
-				"texlab",
-				"intelephense",
-				"clangd",
-				"pyright",
-				"lua-language-server",
+    require("mason-tool-installer").setup({
+      ensure_installed = {
+        "typescript-language-server",
+        "gopls",
+        "dockerls",
+        "svelte-language-server",
+        "tailwindcss-language-server",
+        "jdtls",
+        "texlab",
+        "intelephense",
+        "clangd",
+        "pyright",
+        "lua-language-server",
 
-				-- Formatters
-				"prettierd",
-				"stylua",
-				"black",
-				"clang-format",
-				"pretty-php",
-				"rustfmt",
-				"goimports",
+        -- Formatters
+        "prettierd",
+        "stylua",
+        "black",
+        "clang-format",
+        "pretty-php",
+        "rustfmt",
+        "goimports",
 
-				-- Linters
-				"pylint",
-				"phpcs",
-				"trivy",
+        -- Linters
+        "pylint",
+        "phpcs",
+        "trivy",
 
-				-- Debuggers
-				"codelldb",
-				"debugpy",
-			},
-		})
-	end,
+        -- Debuggers
+        "codelldb",
+        "debugpy",
+      },
+    })
+  end,
 }


### PR DESCRIPTION
Since we already attach LSPs on our own, we don't need mason to do it again.
Tested in js, ts, python and rust