### PR TITLE
[FEATURE] multiline string support in autopair jumps

### DIFF
--- a/lua/hexdigest/plugins/autopairs.lua
+++ b/lua/hexdigest/plugins/autopairs.lua
@@ -29,16 +29,41 @@ return {
       local total_lines = #lines
       local closing_chars = { '"', "'", ")", "}", "]", "`", ">", "$" }
 
+      -- Multi-character sequences to handle specially
+      local multi_char_sequences = { '"""', "'''", "```" }
+
       local function is_whitespace(char)
         return char:match("%s") ~= nil
+      end
+
+      -- Check for multi-character sequences first
+      local function check_multi_char_at_pos(line, pos)
+        for _, seq in ipairs(multi_char_sequences) do
+          if pos + #seq - 1 <= #line then
+            local substr = line:sub(pos, pos + #seq - 1)
+            if substr == seq then
+              return #seq
+            end
+          end
+        end
+        return nil
       end
 
       local current_row, current_col = row, col + 1
       while current_row <= total_lines do
         local line = lines[current_row] or ""
-        for i = current_col, #line do
+        local i = current_col
+        while i <= #line do
           local char = line:sub(i, i)
           if not is_whitespace(char) then
+            -- Check for multi-character sequences first
+            local multi_len = check_multi_char_at_pos(line, i)
+            if multi_len then
+              vim.api.nvim_win_set_cursor(0, { current_row, i + multi_len - 1 })
+              return
+            end
+
+            -- Check for single closing characters
             for _, closing_char in ipairs(closing_chars) do
               if char == closing_char then
                 vim.api.nvim_win_set_cursor(0, { current_row, i })
@@ -47,6 +72,7 @@ return {
             end
             break
           end
+          i = i + 1
         end
         current_row = current_row + 1
         current_col = 1
@@ -56,6 +82,6 @@ return {
       end
 
       vim.api.nvim_feedkeys("jk", "n", false)
-    end, { desc = "LuaSnip jump or jump out of autopairs or insert jk" })
+    end, { desc = "LuaSnip jump or jump out of autopairs" })
   end,
 }


### PR DESCRIPTION
Noticed that jumping over tripe-strings (like in python `"""`, or markdown code-blocks `` ``` ``) only jumps through one of the separators at a time.
This pr improves this behavior.